### PR TITLE
Remove 'Jack'

### DIFF
--- a/cat-names.json
+++ b/cat-names.json
@@ -33,7 +33,6 @@
 	"Gizmo",
 	"Gracie",
 	"Harley",
-	"Jack",
 	"Jasmine",
 	"Jasper",
 	"Kiki",


### PR DESCRIPTION
'Jack' is not a cat's name. It might more plausibly be considered a dog's name. Therefore, remove from the list.